### PR TITLE
support providePreview on macOS 12

### DIFF
--- a/JXLook.xcodeproj/project.pbxproj
+++ b/JXLook.xcodeproj/project.pbxproj
@@ -846,7 +846,7 @@
 		85FC6DD725BAC56E00A1AAF4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = JXQuickLook/JXQuickLook.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -877,7 +877,7 @@
 		85FC6DD825BAC56E00A1AAF4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = JXQuickLook/JXQuickLook.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";

--- a/JXQuickLook/Info.plist
+++ b/JXQuickLook/Info.plist
@@ -26,6 +26,8 @@
 	<dict>
 		<key>NSExtensionAttributes</key>
 		<dict>
+			<key>QLIsDataBasedPreview</key>
+			<true/>
 			<key>QLSupportedContentTypes</key>
 			<array>
 				<string>org.jpeg.jpeg-xl</string>

--- a/JXQuickLook/PreviewViewController.swift
+++ b/JXQuickLook/PreviewViewController.swift
@@ -30,6 +30,18 @@ class PreviewViewController: NSViewController, QLPreviewingController {
         handler(nil)
     }
     */
+    @available(macOSApplicationExtension 12.0, *)
+    func providePreview(for request: QLFilePreviewRequest,
+                        completionHandler handler: @escaping (QLPreviewReply?, Error?) -> Void) {
+        if let img = try? JXL.parse(data: Data(contentsOf: request.fileURL)) {
+            let reply = QLPreviewReply(dataOfContentType: .image, contentSize: img.size) { preview in
+                return img.tiffRepresentation ?? "Unreachable!".data(using: .utf8)!;
+            }
+            handler(reply, nil);
+        }
+        handler(nil, JXLError.cannotDecode);
+    }
+    
     func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {
         
         // Add the supported content types to the QLSupportedContentTypes array in the Info.plist of the extension.

--- a/JXQuickLook/PreviewViewController.swift
+++ b/JXQuickLook/PreviewViewController.swift
@@ -34,12 +34,13 @@ class PreviewViewController: NSViewController, QLPreviewingController {
     func providePreview(for request: QLFilePreviewRequest,
                         completionHandler handler: @escaping (QLPreviewReply?, Error?) -> Void) {
         if let img = try? JXL.parse(data: Data(contentsOf: request.fileURL)) {
-            let reply = QLPreviewReply(dataOfContentType: .image, contentSize: img.size) { preview in
-                return img.tiffRepresentation ?? "Unreachable!".data(using: .utf8)!;
-            }
+            let reply = QLPreviewReply(contextSize: img.size, isBitmap: true, drawUsing: { context, _ in
+                context.draw(img.cgImage(forProposedRect: nil, context: nil, hints: nil)!, in: CGRect(origin: .zero, size: img.size))
+            })
             handler(reply, nil);
+        } else {
+            handler(nil, JXLError.cannotDecode);
         }
-        handler(nil, JXLError.cannotDecode);
     }
     
     func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {


### PR DESCRIPTION
Fixes #12
Resolves #15 

The new QL plugin works well with Finder.
- No weird border
- Zooming is also supported, I don't quite remember if zooming is supported on macOS 11